### PR TITLE
Set check timer to 60 minutes

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -12,17 +12,8 @@ var mofofuraco =
 
   tickerInterval: function()
   {
-    let month = (new Date()).getMonth() + 1;
-    // End of year campaign only runs November and December. Update only once per day
-    // from March to October.
-    if ((month > 1) && (month < 11))
-    {
-      return 24 * 60 * 60 * 1000;
-    }
-    else
-    {
-      return 5000;
-    }
+    // One hour should be fine for now
+    return 60 * 60 * 1000;
   },
 
   timerObserver:
@@ -231,7 +222,7 @@ function startup(data, reason)
       toolbaritem.classList.add("toolbaritem-combined-buttons");
       toolbaritem.classList.add("panel-wide-item");
       toolbaritem.appendChild(label);
-      
+
       let listener =
       {
         onWidgetRemoved: function(aWidgetId, aPrevArea)
@@ -241,7 +232,7 @@ function startup(data, reason)
           mofofuraco.timerStop();
           mofofuraco.isVisible = false;
         },
-  
+
         onCustomizeStart: function(aWindow)
         {
           if (aWindow.document == aDocument)
@@ -253,7 +244,7 @@ function startup(data, reason)
             }
           }
         },
-  
+
         onCustomizeEnd: function(aWindow) {
           if (aWindow.document == aDocument) {
             mofofuraco.checkVisibility(aWindow);
@@ -261,7 +252,7 @@ function startup(data, reason)
         },
       };
       CustomizableUI.addListener(listener);
-  
+
       return toolbaritem;
     }
   });


### PR DESCRIPTION
We're currently running the EOY campaign in Germany. Since the volume of donations is relatively low lets set the timer to check every 60 minutes for the current total instead of once a day like it is currently. This will give us 2 weeks to figure out a better strategy for how often we should check. Maybe something the server provides?
